### PR TITLE
Add QA Wolf tests to test manifest

### DIFF
--- a/test-manifest.js
+++ b/test-manifest.js
@@ -1,3 +1,5 @@
+const env = require("dotenv").config();
+
 const PlaywrightTests = [
   { name: "examples/airbnb.js" },
   { name: "examples/airtable.js" },
@@ -24,6 +26,9 @@ const PlaywrightTests = [
   { name: "examples/unsplash.js" },
   { name: "examples/vscode.js" },
   { name: "examples/yelp.js" },
+  { name: "qawolf/facebook_create_and_delete_post.js", env },
+  { name: "qawolf/facebook_like_and_comment_on_post.js", env },
+  { name: "qawolf/facebook_view_friend_profile.js", env },
 ];
 
 module.exports = { PlaywrightTests };


### PR DESCRIPTION
## Issue

We'd like to run playwright tests created by QA Wolf along with our existing playwright tests during gecko runlive tests

Fixes https://github.com/RecordReplay/ops/issues/267

## Resolution

Somewhat naive but simple approach to adding the QA Wolf tests into our runlive tests by adding them to the manifest and injecting the environment variables (which was already supported) for each.

## Notes

We'll need to figure out how we want to generate the `.env` file. I tested locally by creating the file manually. We could do the same on each build machine but would be better to automate it in some way.