### PR TITLE
Make metadata log file configurable

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import { currentPlatform, spawnChecked } from "./utils";
-const { uploadMetadata } = require("./src/metadata");
+const { uploadMetadata, setMetadataFile } = require("./src/metadata");
 
 const Usage = `
 Usage: ts-node run.ts options
@@ -38,6 +38,8 @@ for (let i = 2; i < process.argv.length; i++) {
     gUseContainer = true;
   } else if (arg == "--env") {
     gEnvironment[process.argv[++i]] = process.argv[++i];
+  } else if (arg === "--metadata") {
+    setMetadataFile(process.argv[++i]);
   } else {
     if (fs.existsSync(`${__dirname}/${arg}`)) {
       gTests.push(arg);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 const playwright = require("@recordreplay/playwright");
 const fs = require("fs");
+const { getMetadataFile } = require("./metadata");
 require("dotenv").config();
 
 let browserName = process.env.PLAYWRIGHT_CHROMIUM ? "chromium" : "firefox";
@@ -132,7 +133,7 @@ async function saveMetadata(page, startTime, success) {
       last_screen,
       duration: new Date() - startTime,
     };
-    fs.appendFileSync("./metadata.log", JSON.stringify(metadata) + "\n");
+    fs.appendFileSync(getMetadataFile(), JSON.stringify(metadata) + "\n");
   } catch (e) {
     error("Unable to populate metadata from page:", e.message);
   }

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -3,6 +3,15 @@ require("dotenv").config();
 const fs = require("fs");
 
 const API = "https://graphql.replay.io/v1/graphql";
+let gMetadataFile = "./metadata.log";
+
+function setMetadataFile(path) {
+  gMetadataFile = path;
+}
+
+function getMetadataFile(path) {
+  return gMetadataFile;
+}
 
 async function upload(name, query, variables) {
   const headers = {
@@ -69,7 +78,7 @@ mutation UpdateTest(
 
 async function uploadMetadata(gRecordingFile) {
   const recordingId = lastLine(gRecordingFile);
-  const metadata = JSON.parse(lastLine("./metadata.log"));
+  const metadata = JSON.parse(lastLine(gMetadataFile));
 
   const variables = {
     recording_id: recordingId,
@@ -89,4 +98,4 @@ async function uploadMetadata(gRecordingFile) {
   return recordingId;
 }
 
-module.exports = { uploadMetadata }
+module.exports = { uploadMetadata, getMetadataFile, setMetadataFile };


### PR DESCRIPTION
Adds a command line option to specify the metadata file which allows us to both not store it within this module and avoid overflowing it when many recordings are ran.