### PR TITLE
Handle SIGTERM events

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -90,6 +90,14 @@ const example = wrapped(async (cbk) => {
       .catch((e) => {});
   };
 
+  function term() {
+    pageLog("SIGTERM Received. Closing browser");
+    // This doesn't forcibly close the browser so there may be lingering actions
+    // that have to complete (or timeout) before the browser closes.
+    browser.close();
+  }
+  process.on("SIGTERM", term);
+
   pageLog("Browser launched");
   let success = true;
 
@@ -117,6 +125,8 @@ const example = wrapped(async (cbk) => {
   } catch (e) {
     error("Error while shutting down browser:", e.message);
   }
+
+  process.off("SIGTERM", term);
 
   return success;
 });


### PR DESCRIPTION
Previously we were ignoring `SIGTERM` events so our runlive tests would request we stop after a timeout but playwright would happily continue in ignorance.

Now we close the browser on `SIGTERM`